### PR TITLE
Switch to flexbox to avoid scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,20 @@
 
   <style>
     body {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      min-height: 300px;
       margin: 0;
       font-family: helvetica, sans-serif;
       font-size: 14px;
     }
 
     header {
-      float: left;
-      width: 100%;
+      display: flex;
     }
 
     h1 {
-      float: left;
       margin: 0;
       padding: 15px 22px;
       background-color: #000;
@@ -26,7 +28,6 @@
     }
 
     .field {
-      float: left;
       padding: 15px 22px;
       border-right: 1px solid #eee;
     }
@@ -39,16 +40,15 @@
     }
 
     ul#colors {
-      display: table;
-      float: left;
-      width: 100%;
-      height: 800px;
+      flex-grow: 1;
       margin: 0;
       padding: 0;
+      display: flex;
     }
 
     ul#colors li {
-      display: table-cell;
+      flex-grow: 1;
+      list-style: none;
     }
   </style>
 


### PR DESCRIPTION
Now the color strips stretch to fill the remaining space between the bottom of the header and the bottom of the browser.